### PR TITLE
Create basic array of indexes from objects for newer versions of Phaser

### DIFF
--- a/src/PathFinderPlugin.js
+++ b/src/PathFinderPlugin.js
@@ -32,7 +32,15 @@ Phaser.Plugin.PathFinderPlugin.prototype.constructor = Phaser.Plugin.PathFinderP
 Phaser.Plugin.PathFinderPlugin.prototype.setGrid = function (grid, walkables, iterationsPerCount) {
     iterationsPerCount = iterationsPerCount || null;
 
-    this._grid = grid;
+    this._grid = [];
+    for (var i = 0; i < grid.length; i++)
+    {
+        this._grid[i] = []
+        for (var j = 0; j < grid[i].length; j++)
+        {
+            this._grid[i][j] = grid[i][j].index
+        }
+    }
     this._walkables = walkables;
 
     this._easyStar.setGrid(this._grid);


### PR DESCRIPTION
Newer versions of Phaser (after 1.1.4) create tilemaps that are arrays of arrays of objects. In the previous version, it was enough to simply copy over the grid, but now it must be remapped from the index of individual objects.

For example, an old map would be [ [1, 2], [1, 2] ] and would now be [ [Object, Object], [Object, Object] ].

Confirmed this is working locally for me, but there may be another solution. :)

Thanks for building this wrapper!
