### PR TITLE
add support for grid just consisting of collision tiles. 0 means walkabl...

### DIFF
--- a/src/PathFinderPlugin.js
+++ b/src/PathFinderPlugin.js
@@ -38,7 +38,10 @@ Phaser.Plugin.PathFinderPlugin.prototype.setGrid = function (grid, walkables, it
         this._grid[i] = []
         for (var j = 0; j < grid[i].length; j++)
         {
-            this._grid[i][j] = grid[i][j].index
+            if (grid[i][j])
+                this._grid[i][j] = grid[i][j].index
+            else
+                this._grid[i][j] = 0
         }
     }
     this._walkables = walkables;


### PR DESCRIPTION
Current implementation only support grids that are fully tiled. I use a collision layer which means there are only tiles where there is collision. This is how I worked around the issue. Then walkables is just an array with [0].
